### PR TITLE
use SSL URL

### DIFF
--- a/TropoCSharp/TropoCreateSession.cs
+++ b/TropoCSharp/TropoCreateSession.cs
@@ -12,7 +12,7 @@ namespace TropoCSharp.Tropo
     public static class TropoCreateSessionExtensions
     {
         // The endpoint for initiating Tropo outbound sessions.
-        private const string CREATE_SESSION_URL = "http://api.tropo.com/1.0/sessions?action={0}&token={1}&";
+        private const string CREATE_SESSION_URL = "https://api.tropo.com/1.0/sessions?action={0}&token={1}&";
 
         // The default action command to send the Tropo outbound session API.
         private const string CREATE_SESSION_ACTION = "create";


### PR DESCRIPTION
Hi,

This will force https when connecting to api.tropo.com. According to the docs, WebRequest.create will parse the URI and determine if SSL is to be used or not.

https://msdn.microsoft.com/en-us/library/ds8bxk2a(v=vs.110).aspx